### PR TITLE
fix(ui): move theme toggle to sidebar and mobile nav (issue #47)

### DIFF
--- a/src/app/split/page.tsx
+++ b/src/app/split/page.tsx
@@ -90,7 +90,7 @@ export default function Home() {
     () => (new Date().getHours() < 17 ? "morning" : "night"),
     []
   );
-  const { theme, setTheme, isNight } = useToodlTheme(initialTheme);
+  const { isNight } = useToodlTheme(initialTheme);
 
   // Memoize the onParams callback to prevent infinite loops
   const handleParamsChange = useCallback((params: ReadonlyURLSearchParams) => {
@@ -370,9 +370,6 @@ export default function Home() {
               heading="Split"
               subheading="Invite your crew, log purchases, and keep every tab honest."
               dark={isNight}
-              theme={theme}
-              onThemeChange={setTheme}
-
             />
             <div
               className={cn(

--- a/src/components/AppTopBar.tsx
+++ b/src/components/AppTopBar.tsx
@@ -5,7 +5,7 @@ import { cloneElement, isValidElement, useMemo } from "react";
 import type { ReactNode } from "react";
 import { cn } from "@/lib/utils";
 import { theme, themeClasses } from "@/lib/theme";
-import type { ToodlTheme } from "@/hooks/useToodlTheme";
+
 
 const PRODUCT_META = {
   expense: {
@@ -42,18 +42,7 @@ const PRODUCT_META = {
 
 type ProductKey = keyof typeof PRODUCT_META;
 
-const THEMES = {
-  morning: {
-    id: "morning" as const,
-    label: "Morning",
-    emoji: "☀️",
-  },
-  night: {
-    id: "night" as const,
-    label: "Night",
-    emoji: "🌙",
-  },
-} as const;
+
 
 export function AppTopBar({
   product,
@@ -63,8 +52,6 @@ export function AppTopBar({
   userSlot,
   className,
   dark = false,
-  theme: currentTheme,
-  onThemeChange,
 }: {
   product: ProductKey;
   heading?: ReactNode;
@@ -73,8 +60,6 @@ export function AppTopBar({
   userSlot?: React.ReactNode;
   className?: string;
   dark?: boolean;
-  theme?: ToodlTheme;
-  onThemeChange?: (theme: ToodlTheme) => void;
 }) {
   const meta = PRODUCT_META[product];
   const mobileUserSlot = useMemo(() => {
@@ -101,9 +86,9 @@ export function AppTopBar({
   const subheadingTextClass = theme.text.tertiary(dark);
   const containerColors = dark
     ? cn(
-        "rounded-[32px] border backdrop-blur px-4 py-6 md:px-6",
-        "border-white/40 bg-gradient-to-br from-slate-900 via-slate-800 to-indigo-900 text-white shadow-lg"
-      )
+      "rounded-[32px] border backdrop-blur px-4 py-6 md:px-6",
+      "border-white/40 bg-gradient-to-br from-slate-900 via-slate-800 to-indigo-900 text-white shadow-lg"
+    )
     : themeClasses.topBar(dark);
   const overlayClass = dark
     ? "" // No overlay needed in night mode - gradient is the background
@@ -122,71 +107,71 @@ export function AppTopBar({
         <div className="flex flex-col gap-3 md:flex-row md:items-center md:justify-between">
           <div className="flex flex-col gap-2">
             <div className="flex items-center gap-3 md:gap-4">
-                <Image
-                  src={meta.icon}
-                  alt={`${product} icon`}
-                  width={64}
-                  height={64}
-                  className="h-16 w-16 shrink-0"
-                  priority
-                />
-                <div className="space-y-1">
-                  {(() => {
-                    const headingContent = heading ?? meta.title;
-                    if (isValidElement(headingContent)) {
-                      return (
-                        <div className={cn("text-lg font-semibold md:text-2xl", headingTextClass)}>
-                          {headingContent}
-                        </div>
-                      );
-                    }
-                    if (
-                      typeof headingContent === "string" ||
-                      typeof headingContent === "number"
-                    ) {
-                      return (
-                        <h1 className={cn("text-lg font-semibold md:text-2xl", headingTextClass)}>
-                          {headingContent}
-                        </h1>
-                      );
-                    }
+              <Image
+                src={meta.icon}
+                alt={`${product} icon`}
+                width={64}
+                height={64}
+                className="h-16 w-16 shrink-0"
+                priority
+              />
+              <div className="space-y-1">
+                {(() => {
+                  const headingContent = heading ?? meta.title;
+                  if (isValidElement(headingContent)) {
                     return (
                       <div className={cn("text-lg font-semibold md:text-2xl", headingTextClass)}>
                         {headingContent}
                       </div>
                     );
-                  })()}
-                  {(() => {
-                    const subheadingContent = subheading ?? meta.subtitle;
-                    if (!subheadingContent) {
-                      return null;
-                    }
-                    if (isValidElement(subheadingContent)) {
-                      return (
-                        <div className={cn("text-xs md:text-base", subheadingTextClass)}>
-                          {subheadingContent}
-                        </div>
-                      );
-                    }
-                    if (
-                      typeof subheadingContent === "string" ||
-                      typeof subheadingContent === "number"
-                    ) {
-                      return (
-                        <p className={cn("text-xs md:text-base", subheadingTextClass)}>
-                          {subheadingContent}
-                        </p>
-                      );
-                    }
+                  }
+                  if (
+                    typeof headingContent === "string" ||
+                    typeof headingContent === "number"
+                  ) {
+                    return (
+                      <h1 className={cn("text-lg font-semibold md:text-2xl", headingTextClass)}>
+                        {headingContent}
+                      </h1>
+                    );
+                  }
+                  return (
+                    <div className={cn("text-lg font-semibold md:text-2xl", headingTextClass)}>
+                      {headingContent}
+                    </div>
+                  );
+                })()}
+                {(() => {
+                  const subheadingContent = subheading ?? meta.subtitle;
+                  if (!subheadingContent) {
+                    return null;
+                  }
+                  if (isValidElement(subheadingContent)) {
                     return (
                       <div className={cn("text-xs md:text-base", subheadingTextClass)}>
                         {subheadingContent}
                       </div>
                     );
-                  })()}
-                </div>
+                  }
+                  if (
+                    typeof subheadingContent === "string" ||
+                    typeof subheadingContent === "number"
+                  ) {
+                    return (
+                      <p className={cn("text-xs md:text-base", subheadingTextClass)}>
+                        {subheadingContent}
+                      </p>
+                    );
+                  }
+                  return (
+                    <div className={cn("text-xs md:text-base", subheadingTextClass)}>
+                      {subheadingContent}
+                    </div>
+                  );
+                })()}
               </div>
             </div>
+          </div>
         </div>
         {actions ? (
           <div className="flex flex-wrap items-center gap-2 md:justify-end">
@@ -202,34 +187,6 @@ export function AppTopBar({
       {mobileUserSlot ? (
         <div className="absolute top-2 right-4 md:hidden">
           {mobileUserSlot}
-        </div>
-      ) : null}
-      {currentTheme && onThemeChange ? (
-        <div className={cn(
-          "absolute bottom-2 right-4 flex gap-1 rounded-full border p-0.5",
-          dark
-            ? "border-white/30 bg-white/10"
-            : "border-slate-200 bg-slate-50/80"
-        )}>
-          {Object.values(THEMES).map((option) => (
-            <button
-              key={option.id}
-              onClick={() => onThemeChange(option.id)}
-              className={cn(
-                "flex items-center justify-center rounded-full px-2 py-1 text-[10px] transition-all",
-                currentTheme === option.id
-                  ? dark
-                    ? "bg-white/20 text-white shadow-sm"
-                    : "bg-white text-slate-900 shadow-sm"
-                  : dark
-                    ? "text-white/60 hover:text-white/80"
-                    : "text-slate-400 hover:text-slate-600"
-              )}
-              title={option.label}
-            >
-              <span className="text-sm leading-none">{option.emoji}</span>
-            </button>
-          ))}
         </div>
       ) : null}
     </header>

--- a/src/components/budget/BudgetExperience.tsx
+++ b/src/components/budget/BudgetExperience.tsx
@@ -703,7 +703,7 @@ const BudgetExperience = () => {
     () => (new Date().getHours() < 17 ? "morning" : "night"),
     []
   );
-  const { theme, setTheme, isNight } = useToodlTheme(initialTheme);
+  const { isNight } = useToodlTheme(initialTheme);
 
   const [user, setUser] = useState<User | null>(null);
   const [userProfile, setUserProfile] = useState<UserProfile | null>(null);
@@ -2681,8 +2681,6 @@ const BudgetExperience = () => {
             heading="Pulse"
             subheading="Sign in to track your finances."
             dark={isNight}
-            theme={theme}
-            onThemeChange={setTheme}
             userSlot={undefined}
           />
           <div className="flex items-center justify-center">
@@ -2803,8 +2801,6 @@ const BudgetExperience = () => {
             heading="Pulse"
             subheading="Pick a workspace to open or start a fresh one for a new goal."
             dark={isNight}
-            theme={theme}
-            onThemeChange={setTheme}
             userSlot={userSlot}
           />
           <Card className="border-none bg-white/85 p-6 shadow-xl shadow-emerald-200/40 backdrop-blur">
@@ -2910,8 +2906,6 @@ const BudgetExperience = () => {
           heading={headingNode}
           subheading={lastUpdatedMessage ?? undefined}
           dark={isNight}
-          theme={theme}
-          onThemeChange={setTheme}
           userSlot={userSlot}
         />
         <div

--- a/src/components/flow/FlowExperience.tsx
+++ b/src/components/flow/FlowExperience.tsx
@@ -521,7 +521,7 @@ export function FlowExperience() {
     () => (new Date().getHours() < 17 ? "morning" : "night"),
     []
   );
-  const { theme, setTheme, isNight } = useToodlTheme(initialTheme);
+  const { isNight } = useToodlTheme(initialTheme);
 
   const timezone = useMemo(
     () => Intl.DateTimeFormat().resolvedOptions().timeZone,
@@ -1084,8 +1084,6 @@ export function FlowExperience() {
           heading="Flow"
           subheading="Design your day, weave priorities with pause, and stay on tempo."
           dark={isNight}
-          theme={theme}
-          onThemeChange={setTheme}
           actions={undefined}
           userSlot={user ? userSlot : undefined}
         />

--- a/src/components/journal/JournalExperience.tsx
+++ b/src/components/journal/JournalExperience.tsx
@@ -385,7 +385,6 @@ const BlogPostView = ({
           heading="Story"
           subheading="A shared reflection."
           dark={isNight}
-          theme={isNight ? "night" : "morning"}
         />
 
         <Card className={cn(
@@ -516,7 +515,7 @@ const JournalExperience = () => {
     () => (new Date().getHours() < 17 ? "morning" : "night"),
     []
   );
-  const { theme, setTheme, isNight } = useToodlTheme(initialTheme);
+  const { isNight } = useToodlTheme(initialTheme);
 
   const handleSignIn = useCallback(
     async (providerType: "google" | "microsoft" | "facebook") => {
@@ -1184,8 +1183,6 @@ const JournalExperience = () => {
             product="journal"
             subheading="Sign in to unlock Story or hop to another Toodl app."
             dark={isNight}
-            theme={theme}
-            onThemeChange={setTheme}
             userSlot={undefined}
           />
           <div className="flex items-center justify-center">
@@ -1331,8 +1328,6 @@ const JournalExperience = () => {
           heading="Story"
           subheading="Capture the story behind the numbers, one guided reflection at a time."
           dark={isNight}
-          theme={theme}
-          onThemeChange={setTheme}
           userSlot={user ? userSlot : undefined}
         />
         <div className={cn(

--- a/src/components/layout/AppSidebar.tsx
+++ b/src/components/layout/AppSidebar.tsx
@@ -11,6 +11,8 @@ import {
     Wallet,
     Workflow,
     Globe,
+    Moon,
+    Sun,
 } from "lucide-react";
 import { cn } from "@/lib/utils";
 import { useToodlTheme } from "@/hooks/useToodlTheme";
@@ -28,7 +30,7 @@ type AppSidebarProps = {
 
 export function AppSidebar({ user, isAnon = false, tier = 'free', onSignOut }: AppSidebarProps) {
     const pathname = usePathname();
-    const { isNight } = useToodlTheme();
+    const { isNight, setTheme } = useToodlTheme();
 
     const NAV_ITEMS = [
         {
@@ -122,6 +124,18 @@ export function AppSidebar({ user, isAnon = false, tier = 'free', onSignOut }: A
             </div>
 
             <div className="flex flex-col items-center gap-4">
+                <button
+                    onClick={() => setTheme(isNight ? "morning" : "night")}
+                    className={cn(
+                        "flex h-10 w-10 items-center justify-center rounded-xl transition-colors",
+                        isNight
+                            ? "text-slate-400 hover:bg-slate-100 hover:text-slate-900"
+                            : "text-slate-500 hover:bg-white/5 hover:text-white"
+                    )}
+                    title={isNight ? "Switch to Light Mode" : "Switch to Dark Mode"}
+                >
+                    {isNight ? <Sun className="h-5 w-5" /> : <Moon className="h-5 w-5" />}
+                </button>
                 {(user || isAnon) && (
                     <>
                         <div className={cn(

--- a/src/components/layout/MobileNav.tsx
+++ b/src/components/layout/MobileNav.tsx
@@ -13,6 +13,8 @@ import {
     Wallet,
     Workflow,
     Globe,
+    Moon,
+    Sun,
 } from "lucide-react";
 import { cn } from "@/lib/utils";
 import { useToodlTheme } from "@/hooks/useToodlTheme";
@@ -38,7 +40,7 @@ type MobileNavProps = {
 
 export function MobileNav({ user, isAnon = false, tier = 'free', onSignOut }: MobileNavProps) {
     const pathname = usePathname();
-    const { isNight } = useToodlTheme();
+    const { isNight, setTheme } = useToodlTheme();
     const [open, setOpen] = useState(false);
 
     const NAV_ITEMS = [
@@ -155,6 +157,21 @@ export function MobileNav({ user, isAnon = false, tier = 'free', onSignOut }: Mo
                                 </Link>
                             );
                         })}
+
+                        <div className={cn("my-2 h-px", isNight ? "bg-slate-800" : "bg-slate-100")} />
+
+                        <button
+                            onClick={() => setTheme(isNight ? "morning" : "night")}
+                            className={cn(
+                                "flex w-full items-center gap-3 rounded-xl px-3 py-2.5 text-sm font-medium transition-colors",
+                                isNight
+                                    ? "text-slate-400 hover:bg-white/5 hover:text-slate-300"
+                                    : "text-slate-500 hover:bg-slate-50 hover:text-slate-700"
+                            )}
+                        >
+                            {isNight ? <Sun className="h-5 w-5" /> : <Moon className="h-5 w-5" />}
+                            {isNight ? "Light Mode" : "Dark Mode"}
+                        </button>
                     </nav>
 
                     <div className="flex flex-col gap-4">

--- a/src/components/scratch/ScratchPadExperience.tsx
+++ b/src/components/scratch/ScratchPadExperience.tsx
@@ -221,7 +221,7 @@ export function ScratchPadExperience() {
     () => (new Date().getHours() < 17 ? "morning" : "night"),
     []
   );
-  const { theme, setTheme, isNight } = useToodlTheme(initialTheme);
+  const { isNight } = useToodlTheme(initialTheme);
 
   useEffect(() => {
     const unsubscribe = onAuthStateChanged(auth, async (current) => {
@@ -897,8 +897,6 @@ export function ScratchPadExperience() {
           heading="Orbit"
           subheading="Collect sparks, links, and notes. Organize them when you're ready."
           dark={isNight}
-          theme={theme}
-          onThemeChange={setTheme}
           actions={
             <Button
               variant="outline"


### PR DESCRIPTION
Relocates the theme toggle from AppTopBar to AppSidebar (desktop) and MobileNav (mobile) to resolve UI overlap issues. Removes theme props from AppTopBar and updates all usages in Journal, Budget, ScratchPad, Flow, and Split experiences.