### PR TITLE
[Auto] Fix #70: Update Flow free time calculation

### DIFF
--- a/src/components/flow/FlowExperience.tsx
+++ b/src/components/flow/FlowExperience.tsx
@@ -85,6 +85,7 @@ import {
   FlowTaskType,
   FLOW_DAY_ORDER,
 } from "@/types/flow";
+import { calculateFreeTime } from "@/lib/flowCalculator";
 import { FLOW_MOOD_OPTIONS } from "@/lib/flowMood";
 import { cn } from "@/lib/utils";
 import { useToodlTheme } from "@/hooks/useToodlTheme";
@@ -1215,27 +1216,14 @@ export function FlowExperience() {
                         )}>
                           <span className="h-1.5 w-1.5 rounded-full bg-emerald-500" />
                           Free time: {(() => {
-                            const start = parseTimeStringToDate(activeDate, settings.sleepEnd);
-                            const end = parseTimeStringToDate(activeDate, settings.sleepStart);
-                            // If sleep start is earlier than sleep end (e.g. 23:00 vs 07:00), it's same day.
-                            // If sleep start is smaller (e.g. 01:00) but meant to be next day, we need to handle that.
-                            // Usually sleepStart is bedtime (e.g. 23:00) and sleepEnd is wake up (e.g. 07:00).
-                            // Active day is sleepEnd to sleepStart.
-                            let activeMinutes = (end.getTime() - start.getTime()) / 1000 / 60;
-                            if (activeMinutes < 0) {
-                              activeMinutes += 24 * 60;
-                            }
-
-                            const committedMinutes = plan?.tasks
-                              .filter((t) =>
-                                t.category !== "play" &&
-                                t.type !== "reminder" &&
-                                t.status !== "skipped"
-                              )
-                              .reduce((acc, t) => acc + t.estimateMinutes, 0) || 0;
-
-                            const freeMinutes = Math.max(0, activeMinutes - committedMinutes);
-                            return `${Math.floor(freeMinutes / 60)}h ${Math.floor(freeMinutes % 60)}m`;
+                            if (!plan || !settings) return "--";
+                            const { hours, minutes } = calculateFreeTime(
+                              now,
+                              activeDate,
+                              settings,
+                              plan.tasks
+                            );
+                            return `${hours}h ${minutes}m`;
                           })()}
                         </div>
                       </div>

--- a/src/lib/flowCalculator.test.ts
+++ b/src/lib/flowCalculator.test.ts
@@ -1,0 +1,121 @@
+import { describe, it, expect } from "vitest";
+import { calculateFreeTime, parseTimeStringToDate } from "./flowCalculator";
+import { FlowSettings, FlowTask } from "@/types/flow";
+
+describe("flowCalculator", () => {
+    const mockSettings: FlowSettings = {
+        workStart: "09:00",
+        sleepStart: "23:00",
+        sleepEnd: "07:00",
+        meals: [],
+        fixedEvents: [],
+        timezone: "UTC",
+        workDays: ["monday", "tuesday", "wednesday", "thursday", "friday"],
+    };
+
+    const baseDate = "2023-10-27"; // A Friday
+
+    const createMockTask = (
+        id: string,
+        category: any,
+        estimateMinutes: number,
+        status: any = "pending"
+    ): FlowTask => ({
+        id,
+        title: "Task",
+        category,
+        type: "chore",
+        estimateMinutes,
+        status,
+        sequence: 0,
+        createdAt: "",
+        updatedAt: "",
+        scheduledStart: null,
+        scheduledEnd: null,
+        actualStart: null,
+        actualEnd: null,
+        notes: null,
+    });
+
+    it("calculates free time correctly when now is before work start", () => {
+        // Now is 08:00. Work starts 09:00. Window should be 09:00 - 23:00 = 14 hours (840 mins).
+        // No tasks.
+        const now = parseTimeStringToDate(baseDate, "08:00").getTime();
+        const result = calculateFreeTime(now, baseDate, mockSettings, []);
+
+        expect(result).toEqual({ hours: 14, minutes: 0 });
+    });
+
+    it("calculates free time correctly when now is during work day", () => {
+        // Now is 13:00. Window should be 13:00 - 23:00 = 10 hours (600 mins).
+        const now = parseTimeStringToDate(baseDate, "13:00").getTime();
+        const result = calculateFreeTime(now, baseDate, mockSettings, []);
+
+        expect(result).toEqual({ hours: 10, minutes: 0 });
+    });
+
+    it("subtracts pending work tasks", () => {
+        // Now is 13:00. Remaining window: 10 hours (600 mins).
+        // 2 hours of pending work.
+        // Free time should be 8 hours.
+        const now = parseTimeStringToDate(baseDate, "13:00").getTime();
+        const tasks = [
+            createMockTask("1", "work", 60),
+            createMockTask("2", "work", 60),
+        ];
+        const result = calculateFreeTime(now, baseDate, mockSettings, tasks);
+
+        expect(result).toEqual({ hours: 8, minutes: 0 });
+    });
+
+    it("does not subtract done tasks", () => {
+        // Now is 13:00. Remaining window: 10 hours (600 mins).
+        // 1 hour pending, 1 hour done.
+        // Free time should be 9 hours.
+        const now = parseTimeStringToDate(baseDate, "13:00").getTime();
+        const tasks = [
+            createMockTask("1", "work", 60, "pending"),
+            createMockTask("2", "work", 60, "done"),
+        ];
+        const result = calculateFreeTime(now, baseDate, mockSettings, tasks);
+
+        expect(result).toEqual({ hours: 9, minutes: 0 });
+    });
+
+    it("does not subtract play tasks", () => {
+        // Now is 13:00. Remaining window: 10 hours (600 mins).
+        // 1 hour pending work, 1 hour pending play.
+        // Free time should be 9 hours (play doesn't reduce free time).
+        const now = parseTimeStringToDate(baseDate, "13:00").getTime();
+        const tasks = [
+            createMockTask("1", "work", 60, "pending"),
+            createMockTask("2", "play", 60, "pending"),
+        ];
+        const result = calculateFreeTime(now, baseDate, mockSettings, tasks);
+
+        expect(result).toEqual({ hours: 9, minutes: 0 });
+    });
+
+    it("returns 0 if committed time exceeds remaining time", () => {
+        // Now is 22:00. Remaining window: 1 hour (60 mins).
+        // 2 hours pending work.
+        // Free time should be 0.
+        const now = parseTimeStringToDate(baseDate, "22:00").getTime();
+        const tasks = [
+            createMockTask("1", "work", 120, "pending"),
+        ];
+        const result = calculateFreeTime(now, baseDate, mockSettings, tasks);
+
+        expect(result).toEqual({ hours: 0, minutes: 0 });
+    });
+
+    it("handles sleepStart being next day (e.g. 01:00)", () => {
+        const lateSettings = { ...mockSettings, sleepStart: "01:00" };
+        // Now is 23:00. Window ends 01:00 next day.
+        // Remaining: 2 hours.
+        const now = parseTimeStringToDate(baseDate, "23:00").getTime();
+        const result = calculateFreeTime(now, baseDate, lateSettings, []);
+
+        expect(result).toEqual({ hours: 2, minutes: 0 });
+    });
+});

--- a/src/lib/flowCalculator.ts
+++ b/src/lib/flowCalculator.ts
@@ -1,0 +1,79 @@
+import { FlowSettings, FlowTask } from "@/types/flow";
+
+export const parseTimeStringToDate = (dateKey: string, time: string) => {
+    // time expected HH:mm
+    const [hours, minutes] = time.split(":").map((value) => Number(value));
+    const [year, month, day] = dateKey.split("-").map((value) => Number(value));
+    return new Date(year, month - 1, day, hours, minutes || 0, 0, 0);
+};
+
+export const calculateFreeTime = (
+    now: number,
+    activeDate: string,
+    settings: FlowSettings,
+    tasks: FlowTask[]
+): { hours: number; minutes: number } => {
+    // 1. Determine the effective start time of the "availability window".
+    //    This is the LATER of:
+    //    - The current time (now)
+    //    - The work start time for the active date
+    const workStart = parseTimeStringToDate(activeDate, settings.workStart);
+    const effectiveStart = new Date(Math.max(now, workStart.getTime()));
+
+    // 2. Determine the end time of the "availability window".
+    //    This is usually sleepStart (bedtime).
+    //    Note: logic from FlowExperience used sleepEnd and sleepStart to determine day length.
+    //    Here we assume the user wants to know how much time is left until they sleep.
+    //    If sleepStart is "07:00" (next day) and activeDate is today, we need to handle crossing midnight?
+    //    The original code did:
+    //      start = sleepEnd (wake up)
+    //      end = sleepStart (bedtime)
+    //      activeMinutes = end - start
+    //    But the issue says "calculate based on the time the page is opened or the work day start time".
+    //    So we should use sleepStart as the hard deadline.
+
+    let windowEnd = parseTimeStringToDate(activeDate, settings.sleepStart);
+
+    // Handle case where sleepStart is technically the next day (e.g. 01:00)
+    // If windowEnd is BEFORE workStart, it probably means it's the next day.
+    if (windowEnd.getTime() < workStart.getTime()) {
+        windowEnd = new Date(windowEnd.getTime() + 24 * 60 * 60 * 1000);
+    }
+
+    // Calculate total remaining available minutes
+    let remainingMinutes = (windowEnd.getTime() - effectiveStart.getTime()) / 1000 / 60;
+
+    // If we are already past the end time, 0 free time.
+    if (remainingMinutes < 0) {
+        return { hours: 0, minutes: 0 };
+    }
+
+    // 3. Calculate committed time from PENDING tasks.
+    //    We only care about tasks that are NOT done/skipped.
+    //    We also exclude "play" (fun stuff doesn't count as 'committed' work usually? Or maybe it does?)
+    //    Original code excluded "play" and "reminder".
+    //    "Free time" usually means "Time I have available to do whatever I want (including Play)".
+    //    So we subtract "Work", "Chores", "Growth", etc.
+    //    But if I schedule "Play", does that reduce my "Free time"?
+    //    Technically yes, if I scheduled it, it's "committed".
+    //    BUT the original code explicitly EXCLUDED "play" from committedMinutes:
+    //      t.category !== "play" && t.type !== "reminder"
+    //    So we will stick to that logic for now.
+
+    const committedMinutes = tasks
+        .filter((t) =>
+            t.category !== "play" &&
+            t.type !== "reminder" &&
+            t.status !== "done" &&
+            t.status !== "skipped" &&
+            t.status !== "failed"
+        )
+        .reduce((acc, t) => acc + t.estimateMinutes, 0);
+
+    const freeMinutes = Math.max(0, remainingMinutes - committedMinutes);
+
+    return {
+        hours: Math.floor(freeMinutes / 60),
+        minutes: Math.floor(freeMinutes % 60),
+    };
+};

--- a/vitest.config.ts
+++ b/vitest.config.ts
@@ -4,7 +4,7 @@ import { defineConfig } from "vitest/config";
 export default defineConfig({
   test: {
     environment: "node",
-    include: ["tests/**/*.test.ts"],
+    include: ["tests/**/*.test.ts", "src/**/*.test.ts"],
     reporters: "default",
     coverage: {
       provider: "v8",


### PR DESCRIPTION
Fixes #70.

Updates the 'Free time' calculation in Flow to be more accurate.
- Uses the later of 'current time' or 'work start time' as the start of the availability window.
- Subtracts only pending tasks (excluding 'play' and 'reminder') from the remaining time.
- Extracted logic to `src/lib/flowCalculator.ts` with unit tests.

Test command: `npm test src/lib/flowCalculator.test.ts`