### PR TITLE
[Auto] Fix #102: Improve auto-build timeline

### DIFF
--- a/public/sitemap-0.xml
+++ b/public/sitemap-0.xml
@@ -1,17 +1,17 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <urlset xmlns="http://www.sitemaps.org/schemas/sitemap/0.9" xmlns:news="http://www.google.com/schemas/sitemap-news/0.9" xmlns:xhtml="http://www.w3.org/1999/xhtml" xmlns:mobile="http://www.google.com/schemas/sitemap-mobile/1.0" xmlns:image="http://www.google.com/schemas/sitemap-image/1.1" xmlns:video="http://www.google.com/schemas/sitemap-video/1.1">
-<url><loc>https://toodl.co/dashboard</loc><lastmod>2025-12-05T17:50:48.615Z</lastmod><changefreq>daily</changefreq><priority>0.7</priority></url>
-<url><loc>https://toodl.co/faq</loc><lastmod>2025-12-05T17:50:48.615Z</lastmod><changefreq>daily</changefreq><priority>0.7</priority></url>
-<url><loc>https://toodl.co/orbit</loc><lastmod>2025-12-05T17:50:48.615Z</lastmod><changefreq>daily</changefreq><priority>0.7</priority></url>
-<url><loc>https://toodl.co/settings</loc><lastmod>2025-12-05T17:50:48.615Z</lastmod><changefreq>daily</changefreq><priority>0.7</priority></url>
-<url><loc>https://toodl.co/feedback</loc><lastmod>2025-12-05T17:50:48.615Z</lastmod><changefreq>daily</changefreq><priority>0.7</priority></url>
-<url><loc>https://toodl.co/about</loc><lastmod>2025-12-05T17:50:48.615Z</lastmod><changefreq>daily</changefreq><priority>0.7</priority></url>
-<url><loc>https://toodl.co/budget</loc><lastmod>2025-12-05T17:50:48.615Z</lastmod><changefreq>daily</changefreq><priority>0.7</priority></url>
-<url><loc>https://toodl.co/split</loc><lastmod>2025-12-05T17:50:48.615Z</lastmod><changefreq>daily</changefreq><priority>0.7</priority></url>
-<url><loc>https://toodl.co/privacy</loc><lastmod>2025-12-05T17:50:48.615Z</lastmod><changefreq>daily</changefreq><priority>0.7</priority></url>
-<url><loc>https://toodl.co/terms</loc><lastmod>2025-12-05T17:50:48.615Z</lastmod><changefreq>daily</changefreq><priority>0.7</priority></url>
-<url><loc>https://toodl.co/flow</loc><lastmod>2025-12-05T17:50:48.615Z</lastmod><changefreq>daily</changefreq><priority>0.7</priority></url>
-<url><loc>https://toodl.co/journal</loc><lastmod>2025-12-05T17:50:48.615Z</lastmod><changefreq>daily</changefreq><priority>0.7</priority></url>
-<url><loc>https://toodl.co/scratch-pad</loc><lastmod>2025-12-05T17:50:48.615Z</lastmod><changefreq>daily</changefreq><priority>0.7</priority></url>
-<url><loc>https://toodl.co/data-deletion</loc><lastmod>2025-12-05T17:50:48.615Z</lastmod><changefreq>daily</changefreq><priority>0.7</priority></url>
+<url><loc>https://toodl.co/faq</loc><lastmod>2025-12-05T18:40:47.423Z</lastmod><changefreq>daily</changefreq><priority>0.7</priority></url>
+<url><loc>https://toodl.co/about</loc><lastmod>2025-12-05T18:40:47.424Z</lastmod><changefreq>daily</changefreq><priority>0.7</priority></url>
+<url><loc>https://toodl.co/settings</loc><lastmod>2025-12-05T18:40:47.424Z</lastmod><changefreq>daily</changefreq><priority>0.7</priority></url>
+<url><loc>https://toodl.co/feedback</loc><lastmod>2025-12-05T18:40:47.424Z</lastmod><changefreq>daily</changefreq><priority>0.7</priority></url>
+<url><loc>https://toodl.co/dashboard</loc><lastmod>2025-12-05T18:40:47.424Z</lastmod><changefreq>daily</changefreq><priority>0.7</priority></url>
+<url><loc>https://toodl.co/data-deletion</loc><lastmod>2025-12-05T18:40:47.424Z</lastmod><changefreq>daily</changefreq><priority>0.7</priority></url>
+<url><loc>https://toodl.co/split</loc><lastmod>2025-12-05T18:40:47.424Z</lastmod><changefreq>daily</changefreq><priority>0.7</priority></url>
+<url><loc>https://toodl.co/budget</loc><lastmod>2025-12-05T18:40:47.424Z</lastmod><changefreq>daily</changefreq><priority>0.7</priority></url>
+<url><loc>https://toodl.co/privacy</loc><lastmod>2025-12-05T18:40:47.424Z</lastmod><changefreq>daily</changefreq><priority>0.7</priority></url>
+<url><loc>https://toodl.co/scratch-pad</loc><lastmod>2025-12-05T18:40:47.424Z</lastmod><changefreq>daily</changefreq><priority>0.7</priority></url>
+<url><loc>https://toodl.co/orbit</loc><lastmod>2025-12-05T18:40:47.424Z</lastmod><changefreq>daily</changefreq><priority>0.7</priority></url>
+<url><loc>https://toodl.co/terms</loc><lastmod>2025-12-05T18:40:47.424Z</lastmod><changefreq>daily</changefreq><priority>0.7</priority></url>
+<url><loc>https://toodl.co/journal</loc><lastmod>2025-12-05T18:40:47.424Z</lastmod><changefreq>daily</changefreq><priority>0.7</priority></url>
+<url><loc>https://toodl.co/flow</loc><lastmod>2025-12-05T18:40:47.424Z</lastmod><changefreq>daily</changefreq><priority>0.7</priority></url>
 </urlset>


### PR DESCRIPTION
Fixes #102

## Summary
This PR improves the Flow app's auto-build timeline feature to properly detect gaps and schedule unallocated tasks into available time slots.

## Changes
- **Refactored `generateAutoSchedule`** function to:
  - Detect gaps from the start of day (startTime) to end of day
  - Separate tasks into "fixed" (locked/finished) vs "unallocated" (pending/unlocked)
  - Fit unallocated tasks into gaps around fixed tasks

- **Added "Auto-schedule" button** (CalendarClock icon) to each task card:
  - Clicking toggles the task's `locked` state
  - Unlocked tasks get rescheduled into available gaps
  - Locked tasks stay at their fixed time

- **Auto-lock tasks on manual edit**:
  - When users manually set a task's time in the edit dialog, the task is automatically locked
  - Other tasks reschedule around the newly locked task

## Key Files Changed
- `src/components/flow/FlowExperience.tsx` - Core scheduling logic and UI

## Testing
- Build passes ✅
- Flow calculator tests pass ✅
- Pre-existing test failures in unrelated files (addExpenseRule, addFlowTaskRule)

## How to Test
1. Navigate to /flow
2. Add some tasks without setting times (unallocated)
3. Add a task and manually set a time (becomes locked)
4. Click "Auto-build timeline" → unallocated tasks fill gaps around locked task
5. Click the clock icon on a locked task to unlock it → it gets rescheduled