### PR TITLE
[Auto] Fix #122: Add Quest to mobile menu

### DIFF
--- a/public/sitemap-0.xml
+++ b/public/sitemap-0.xml
@@ -1,17 +1,18 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <urlset xmlns="http://www.sitemaps.org/schemas/sitemap/0.9" xmlns:news="http://www.google.com/schemas/sitemap-news/0.9" xmlns:xhtml="http://www.w3.org/1999/xhtml" xmlns:mobile="http://www.google.com/schemas/sitemap-mobile/1.0" xmlns:image="http://www.google.com/schemas/sitemap-image/1.1" xmlns:video="http://www.google.com/schemas/sitemap-video/1.1">
-<url><loc>https://toodl.co/data-deletion</loc><lastmod>2025-12-24T10:02:56.117Z</lastmod><changefreq>daily</changefreq><priority>0.7</priority></url>
-<url><loc>https://toodl.co/faq</loc><lastmod>2025-12-24T10:02:56.118Z</lastmod><changefreq>daily</changefreq><priority>0.7</priority></url>
-<url><loc>https://toodl.co/about</loc><lastmod>2025-12-24T10:02:56.118Z</lastmod><changefreq>daily</changefreq><priority>0.7</priority></url>
-<url><loc>https://toodl.co/settings</loc><lastmod>2025-12-24T10:02:56.118Z</lastmod><changefreq>daily</changefreq><priority>0.7</priority></url>
-<url><loc>https://toodl.co/split</loc><lastmod>2025-12-24T10:02:56.118Z</lastmod><changefreq>daily</changefreq><priority>0.7</priority></url>
-<url><loc>https://toodl.co/dashboard</loc><lastmod>2025-12-24T10:02:56.118Z</lastmod><changefreq>daily</changefreq><priority>0.7</priority></url>
-<url><loc>https://toodl.co/feedback</loc><lastmod>2025-12-24T10:02:56.118Z</lastmod><changefreq>daily</changefreq><priority>0.7</priority></url>
-<url><loc>https://toodl.co/orbit</loc><lastmod>2025-12-24T10:02:56.118Z</lastmod><changefreq>daily</changefreq><priority>0.7</priority></url>
-<url><loc>https://toodl.co/scratch-pad</loc><lastmod>2025-12-24T10:02:56.118Z</lastmod><changefreq>daily</changefreq><priority>0.7</priority></url>
-<url><loc>https://toodl.co/terms</loc><lastmod>2025-12-24T10:02:56.118Z</lastmod><changefreq>daily</changefreq><priority>0.7</priority></url>
-<url><loc>https://toodl.co/journal</loc><lastmod>2025-12-24T10:02:56.118Z</lastmod><changefreq>daily</changefreq><priority>0.7</priority></url>
-<url><loc>https://toodl.co/budget</loc><lastmod>2025-12-24T10:02:56.118Z</lastmod><changefreq>daily</changefreq><priority>0.7</priority></url>
-<url><loc>https://toodl.co/privacy</loc><lastmod>2025-12-24T10:02:56.118Z</lastmod><changefreq>daily</changefreq><priority>0.7</priority></url>
-<url><loc>https://toodl.co/flow</loc><lastmod>2025-12-24T10:02:56.118Z</lastmod><changefreq>daily</changefreq><priority>0.7</priority></url>
+<url><loc>https://toodl.co/about</loc><lastmod>2025-12-26T23:45:20.399Z</lastmod><changefreq>daily</changefreq><priority>0.7</priority></url>
+<url><loc>https://toodl.co/data-deletion</loc><lastmod>2025-12-26T23:45:20.399Z</lastmod><changefreq>daily</changefreq><priority>0.7</priority></url>
+<url><loc>https://toodl.co/faq</loc><lastmod>2025-12-26T23:45:20.399Z</lastmod><changefreq>daily</changefreq><priority>0.7</priority></url>
+<url><loc>https://toodl.co/quest</loc><lastmod>2025-12-26T23:45:20.399Z</lastmod><changefreq>daily</changefreq><priority>0.7</priority></url>
+<url><loc>https://toodl.co/split</loc><lastmod>2025-12-26T23:45:20.399Z</lastmod><changefreq>daily</changefreq><priority>0.7</priority></url>
+<url><loc>https://toodl.co/privacy</loc><lastmod>2025-12-26T23:45:20.399Z</lastmod><changefreq>daily</changefreq><priority>0.7</priority></url>
+<url><loc>https://toodl.co/feedback</loc><lastmod>2025-12-26T23:45:20.399Z</lastmod><changefreq>daily</changefreq><priority>0.7</priority></url>
+<url><loc>https://toodl.co/budget</loc><lastmod>2025-12-26T23:45:20.400Z</lastmod><changefreq>daily</changefreq><priority>0.7</priority></url>
+<url><loc>https://toodl.co/scratch-pad</loc><lastmod>2025-12-26T23:45:20.400Z</lastmod><changefreq>daily</changefreq><priority>0.7</priority></url>
+<url><loc>https://toodl.co/flow</loc><lastmod>2025-12-26T23:45:20.400Z</lastmod><changefreq>daily</changefreq><priority>0.7</priority></url>
+<url><loc>https://toodl.co/dashboard</loc><lastmod>2025-12-26T23:45:20.400Z</lastmod><changefreq>daily</changefreq><priority>0.7</priority></url>
+<url><loc>https://toodl.co/terms</loc><lastmod>2025-12-26T23:45:20.400Z</lastmod><changefreq>daily</changefreq><priority>0.7</priority></url>
+<url><loc>https://toodl.co/orbit</loc><lastmod>2025-12-26T23:45:20.400Z</lastmod><changefreq>daily</changefreq><priority>0.7</priority></url>
+<url><loc>https://toodl.co/journal</loc><lastmod>2025-12-26T23:45:20.400Z</lastmod><changefreq>daily</changefreq><priority>0.7</priority></url>
+<url><loc>https://toodl.co/settings</loc><lastmod>2025-12-26T23:45:20.400Z</lastmod><changefreq>daily</changefreq><priority>0.7</priority></url>
 </urlset>

--- a/src/components/layout/MobileNav.tsx
+++ b/src/components/layout/MobileNav.tsx
@@ -17,6 +17,7 @@ import {
     Sun,
     Settings,
     MessageSquare,
+    Target,
 } from "lucide-react";
 import { cn } from "@/lib/utils";
 import { useToodlTheme } from "@/hooks/useToodlTheme";
@@ -78,6 +79,11 @@ export function MobileNav({ user, isAnon = false, tier = 'free', onSignOut }: Mo
             label: "Orbit",
             href: "/orbit",
             icon: Globe,
+        },
+        {
+            label: "Quest",
+            href: "/quest",
+            icon: Target,
         },
     ];
 


### PR DESCRIPTION
Fixes #122

## Summary
Adds the Quest navigation item to the mobile menu (`MobileNav.tsx`), matching the existing desktop sidebar.

## Changes
- Imported `Target` icon from lucide-react  
- Added Quest item to `NAV_ITEMS` array with `/quest` href

## Key file changed
- `src/components/layout/MobileNav.tsx`

## Verification
- Build passes (`npm run build`)
- Tested on mobile viewport: Quest appears with Target icon, clicking navigates to /quest and closes menu