### PR TITLE
[Auto] Fix #126: Fix minor bugs in news cards

### DIFF
--- a/src/app/dashboard/page.tsx
+++ b/src/app/dashboard/page.tsx
@@ -3305,7 +3305,7 @@ function NewsFeedCard({
                   <Button
                     size="icon"
                     variant="ghost"
-                    onClick={handlePrevious}
+                    onClick={(e) => { e.stopPropagation(); handlePrevious(); }}
                     className={cn("h-8 w-8 rounded-full", isNight ? "hover:bg-white/10" : "hover:bg-indigo-100")}
                   >
                     <ChevronLeft className="h-4 w-4" />
@@ -3316,7 +3316,7 @@ function NewsFeedCard({
                   <Button
                     size="icon"
                     variant="ghost"
-                    onClick={handleNext}
+                    onClick={(e) => { e.stopPropagation(); handleNext(); }}
                     className={cn("h-8 w-8 rounded-full", isNight ? "hover:bg-white/10" : "hover:bg-indigo-100")}
                   >
                     <ChevronRight className="h-4 w-4" />

--- a/src/components/orbit/NewsReaderDialog.tsx
+++ b/src/components/orbit/NewsReaderDialog.tsx
@@ -2,7 +2,6 @@
 
 import { Dialog, DialogContent, DialogTitle } from "@/components/ui/dialog";
 import { OrbitInsightCard } from "@/types/orbit";
-import { X } from "lucide-react";
 import Image from "next/image";
 import { Button } from "@/components/ui/button";
 import { ScrollArea } from "@/components/ui/scroll-area";
@@ -43,15 +42,6 @@ export function NewsReaderDialog({
                         />
                     )}
                     <div className="absolute inset-0 bg-gradient-to-t from-black/80 via-black/30 to-transparent" />
-
-                    <Button
-                        variant="ghost"
-                        size="icon"
-                        className="absolute top-4 right-4 text-white hover:bg-white/20 rounded-full"
-                        onClick={() => onOpenChange(false)}
-                    >
-                        <X className="h-5 w-5" />
-                    </Button>
 
                     <div className="absolute bottom-6 left-6 right-6">
                         <span className="inline-block px-2 py-0.5 rounded-full text-[10px] font-bold uppercase tracking-wider bg-white/20 text-white backdrop-blur-sm mb-3">


### PR DESCRIPTION
Fixes #126

## Summary
This PR fixes two bugs in the news cards:

1. **Removed duplicate close button** - The `NewsReaderDialog` component had a custom X button, but the underlying `DialogContent` component already provides one. Removed the custom button.

2. **Fixed arrow navigation opening card** - When clicking the left/right arrows to navigate between news items, the click event was bubbling up to the card's onClick handler, causing the news dialog to open. Added `e.stopPropagation()` to both arrow button handlers.

## Files Changed
- `src/components/orbit/NewsReaderDialog.tsx` - Removed duplicate close button and unused X import
- `src/app/dashboard/page.tsx` - Added e.stopPropagation() to arrow button handlers in NewsFeedCard

## Testing
- Build passes successfully
- Arrow buttons now only navigate without opening the dialog
- Dialog now shows only one close button